### PR TITLE
Add desktop app scaffold with stub parser

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,9 @@
+"""Application entry point for the build plan estimator desktop app."""
+
+from __future__ import annotations
+
+from src.ui.app import run_app
+
+
+if __name__ == "__main__":
+    run_app()

--- a/src/engine/pdf_parser.py
+++ b/src/engine/pdf_parser.py
@@ -1,159 +1,19 @@
-"""Utilities for parsing plan PDFs for basic measurement metadata."""
+"""Stubbed PDF parsing utilities for the desktop application scaffold."""
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
-from typing import Iterable, List, Sequence
+from typing import Any, Dict
 
-import pdfplumber
+ParsedPDFMetadata = Dict[str, Any]
 
-# Normalization helpers for quote and dash characters that commonly appear in PDFs.
-_CHARACTER_TRANSLATION = str.maketrans(
-    {
-        "’": "'",
-        "‘": "'",
-        "′": "'",
-        "“": '"',
-        "”": '"',
-        "″": '"',
-        "–": "-",
-        "—": "-",
-        "−": "-",
+
+def parse_pdf(file_path: str | Path) -> ParsedPDFMetadata:  # noqa: ARG001
+    """Return placeholder data for the provided PDF file path."""
+
+    return {
+        "page_number": 1,
+        "page_size": [1000, 2000],
+        "scale": "1/4\" = 1'-0\"",
+        "dimensions": ["12'-6\"", "15.5"],
     }
-)
-
-# Regex designed to capture scale annotations such as `1/4" = 1'-0"`.
-_SCALE_PATTERN = re.compile(
-    r"""
-    (?:
-        \d+\s*/\s*\d+\s*[\"”″]?   # fraction with optional inch mark
-    )
-    \s*=\s*
-    (?:
-        \d+\s*[’'′]\s*-?\s*\d+[\"”″]?  # feet-inches with optional hyphen and inch mark
-    )
-    """,
-    re.VERBOSE,
-)
-
-# Regex patterns that represent common dimension formats we want to extract.
-_DIMENSION_PATTERNS: Sequence[re.Pattern[str]] = (
-    # Feet and inches, e.g. 12'-6" or 8' 0"
-    re.compile(r"\d+\s*[’'′]\s*-?\s*\d+[\"”″]?"),
-    # Inch-only values such as 9" (avoid matching the inch component of a feet-inch value)
-    re.compile(r"(?<![\d-])\d+\s*[\"”″]"),
-    # Decimal values like 15.5
-    re.compile(r"\d+\.\d+"),
-    # Fractional values such as 1/4"
-    re.compile(r"\d+\s*/\s*\d+[\"”″]?"),
-)
-
-
-def _normalize_characters(value: str) -> str:
-    """Replace curly quotes and dashes with their ASCII counterparts."""
-    return value.translate(_CHARACTER_TRANSLATION)
-
-
-def _collapse_whitespace(value: str) -> str:
-    """Collapse whitespace runs into single spaces and trim the result."""
-    return " ".join(value.split())
-
-
-def _normalize_measurement(value: str) -> str:
-    """Standardize measurement text for consistent downstream comparisons."""
-    value = _normalize_characters(value)
-    value = value.strip()
-    # Remove superfluous whitespace around separators that commonly appear in measurements.
-    value = re.sub(r"\s*/\s*", "/", value)
-    value = re.sub(r"\s*-\s*", "-", value)
-    value = re.sub(r"\s*'\s*", "'", value)
-    value = re.sub(r'\s*"\s*', '"', value)
-    return value
-
-
-def _normalize_scale(value: str) -> str:
-    """Normalize scale annotations to a consistent textual representation."""
-    value = _normalize_characters(value)
-    value = re.sub(r"\s*/\s*", "/", value)
-    value = re.sub(r"\s*-\s*", "-", value)
-    value = re.sub(r"\s*'\s*", "'", value)
-    value = re.sub(r'\s*"\s*', '"', value)
-    value = re.sub(r"\s*=\s*", " = ", value)
-    return _collapse_whitespace(value)
-
-
-def _extract_scale(text: str) -> str | None:
-    """Locate and normalize the first scale annotation found in the supplied text."""
-    if not text:
-        return None
-    match = _SCALE_PATTERN.search(_normalize_characters(text))
-    if not match:
-        return None
-    return _normalize_scale(match.group(0))
-
-
-def _iter_dimension_strings(texts: Iterable[str]) -> Iterable[str]:
-    for text in texts:
-        if not text:
-            continue
-        normalized = _normalize_characters(text)
-        for pattern in _DIMENSION_PATTERNS:
-            for match in pattern.finditer(normalized):
-                yield _normalize_measurement(match.group(0))
-
-
-def _extract_dimensions(texts: Iterable[str], scale: str | None) -> List[str]:
-    """Extract unique dimension strings from the provided text fragments."""
-    seen: List[str] = []
-    for measurement in _iter_dimension_strings(texts):
-        if not measurement:
-            continue
-        if scale and measurement in scale:
-            # Avoid echoing dimension fragments that originate from the scale annotation itself.
-            continue
-        if measurement not in seen:
-            seen.append(measurement)
-    return seen
-
-
-def parse_pdf(file_path: str | Path) -> List[dict]:
-    """Parse a PDF and return per-page metadata for use in takeoff estimation.
-
-    The result is a list of dictionaries, each containing:
-        - ``page_number``: 1-based index of the page in the PDF
-        - ``page_size``: tuple of page width and height in points
-        - ``scale``: detected scale annotation text, or ``None`` if not found
-        - ``dimensions``: ordered list of distinct dimension-like strings discovered on the page
-    """
-
-    path = Path(file_path)
-    if not path.exists():
-        raise FileNotFoundError(f"PDF file not found: {file_path}")
-
-    results: List[dict] = []
-    with pdfplumber.open(str(path)) as pdf:
-        for page_number, page in enumerate(pdf.pages, start=1):
-            page_text = page.extract_text() or ""
-            scale = _extract_scale(page_text)
-
-            text_fragments: List[str] = [page_text]
-            try:
-                for word in page.extract_words():
-                    value = word.get("text")
-                    if value:
-                        text_fragments.append(value)
-            except Exception:
-                # ``extract_words`` can fail on some PDFs; fall back to the raw text only.
-                pass
-
-            dimensions = _extract_dimensions(text_fragments, scale)
-            results.append(
-                {
-                    "page_number": page_number,
-                    "page_size": (page.width, page.height),
-                    "scale": scale,
-                    "dimensions": dimensions,
-                }
-            )
-    return results

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,0 +1,79 @@
+"""PyQt5 application scaffolding for the build plan estimator."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from PyQt5.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QMessageBox,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.engine.pdf_parser import parse_pdf
+
+
+class MainWindow(QWidget):
+    """Main window containing controls for selecting and displaying PDF data."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("Build Plan Estimator")
+        self.resize(640, 480)
+
+        self._select_button = QPushButton("Select PDF", self)
+        self._select_button.clicked.connect(self._handle_select_pdf)
+
+        self._results_view = QTextEdit(self)
+        self._results_view.setReadOnly(True)
+        self._results_view.setPlaceholderText(
+            "Select a PDF to view placeholder parsing results."
+        )
+
+        layout = QVBoxLayout()
+        layout.addWidget(self._select_button)
+        layout.addWidget(self._results_view)
+        self.setLayout(layout)
+
+    def _handle_select_pdf(self) -> None:
+        """Prompt the user for a PDF file and display placeholder parse data."""
+
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select PDF",
+            str(Path.home()),
+            "PDF Files (*.pdf);;All Files (*)",
+        )
+        if not file_path:
+            return
+
+        try:
+            parsed_data = parse_pdf(file_path)
+        except Exception as exc:  # pragma: no cover - UI feedback path
+            QMessageBox.critical(
+                self,
+                "Parsing Error",
+                f"An error occurred while parsing the PDF:\n{exc}",
+            )
+            return
+
+        formatted = json.dumps(parsed_data, indent=2)
+        self._results_view.setPlainText(formatted)
+
+
+def run_app() -> None:
+    """Create and execute the Qt application."""
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(sys.argv)
+
+    window = MainWindow()
+    window.show()
+    app.exec_()


### PR DESCRIPTION
## Summary
- add a desktop application entry point that launches the PyQt UI
- scaffold a PyQt5 window with a Select PDF button and results display
- replace the parser implementation with a placeholder stub and update its tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0cf002e4483318101f1ed9c6704d2