### PR TITLE
Add PDF rendering, room detection, and material estimates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pdfminer.six==20250506
 pdfplumber==0.11.7
 pillow==11.3.0
 pluggy==1.6.0
+PyMuPDF==1.26.4
 pycparser==2.23
 Pygments==2.19.2
 PyPDF2==3.0.1

--- a/src/engine/pdf_parser.py
+++ b/src/engine/pdf_parser.py
@@ -1,19 +1,191 @@
-"""Stubbed PDF parsing utilities for the desktop application scaffold."""
+"""PDF utilities for rendering plan pages and estimating materials."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict
+from typing import Iterable, List
 
-ParsedPDFMetadata = Dict[str, Any]
+import fitz
+import numpy as np
+from PyQt5.QtGui import QImage
+
+try:
+    import cv2
+except ImportError as exc:  # pragma: no cover - dependency error path
+    raise RuntimeError(
+        "OpenCV (cv2) is required for room detection but is not installed"
+    ) from exc
+
+PIXEL_TO_FEET = 0.1
+WALL_HEIGHT_FT = 8.0
+STUD_SPACING_FT = 16.0 / 12.0
 
 
-def parse_pdf(file_path: str | Path) -> ParsedPDFMetadata:  # noqa: ARG001
-    """Return placeholder data for the provided PDF file path."""
+@dataclass(frozen=True)
+class RoomEstimate:
+    """Container describing a detected room and the material estimates."""
+
+    rect: tuple[int, int, int, int]
+    flooring_sqft: float
+    drywall_sqft: float
+    studs: int
+
+
+def _ensure_path(file_path: str | Path) -> Path:
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"PDF file not found: {file_path}")
+    return path
+
+
+def render_pdf_to_image(file_path: str | Path) -> tuple[QImage, np.ndarray]:
+    """Render the first page of *file_path* and return it as a Qt image."""
+
+    path = _ensure_path(file_path)
+    document = fitz.open(path)
+    if document.page_count == 0:
+        raise ValueError("The provided PDF does not contain any pages")
+
+    page = document.load_page(0)
+    zoom_matrix = fitz.Matrix(2.0, 2.0)
+    pixmap = page.get_pixmap(matrix=zoom_matrix, alpha=False)
+
+    if pixmap.n == 4:
+        image_format = QImage.Format_RGBA8888
+    elif pixmap.n == 3:
+        image_format = QImage.Format_RGB888
+    else:
+        image_format = QImage.Format_Grayscale8
+
+    image = QImage(
+        pixmap.samples,
+        pixmap.width,
+        pixmap.height,
+        pixmap.stride,
+        image_format,
+    ).copy()
+
+    row_stride = pixmap.stride
+    array = np.frombuffer(pixmap.samples, dtype=np.uint8).copy()
+    array = array.reshape((pixmap.height, row_stride))
+    array = array[:, : pixmap.width * pixmap.n]
+    array = array.reshape((pixmap.height, pixmap.width, pixmap.n))
+
+    if pixmap.n == 1:
+        array = np.repeat(array, 3, axis=2)
+
+    if array.shape[2] == 3:
+        alpha_channel = np.full(
+            (pixmap.height, pixmap.width, 1), 255, dtype=np.uint8
+        )
+        array = np.concatenate([array, alpha_channel], axis=2)
+
+    return image, array
+
+
+def _qimage_to_numpy(image: QImage) -> np.ndarray:
+    converted = image.convertToFormat(QImage.Format_RGBA8888)
+    ptr = converted.bits()
+    bytes_per_line = converted.bytesPerLine()
+    ptr.setsize(converted.height() * bytes_per_line)
+    array = np.frombuffer(ptr, dtype=np.uint8).copy()
+    array = array.reshape((converted.height(), bytes_per_line))
+    array = array[:, : converted.width() * 4]
+    array = array.reshape((converted.height(), converted.width(), 4))
+    return array
+
+
+def _filter_contours(
+    contours: Iterable[np.ndarray],
+    width: int,
+    height: int,
+) -> List[np.ndarray]:
+    filtered: List[np.ndarray] = []
+    min_area = max(width * height * 0.0005, 2000)
+    for contour in contours:
+        x, y, w, h = cv2.boundingRect(contour)
+        area = w * h
+        if area < min_area:
+            continue
+        if w >= width * 0.95 and h >= height * 0.95:
+            continue
+        filtered.append(contour)
+    return filtered
+
+
+def detect_rooms(image: QImage | np.ndarray) -> list[RoomEstimate]:
+    """Identify room-like regions within *image* and estimate materials."""
+
+    if isinstance(image, QImage):
+        rgba = _qimage_to_numpy(image)
+    else:
+        rgba = image
+
+    if rgba.ndim != 3 or rgba.shape[2] not in {3, 4}:
+        raise ValueError("Image must be an RGB or RGBA array")
+
+    if rgba.shape[2] == 4:
+        bgr = cv2.cvtColor(rgba, cv2.COLOR_RGBA2BGR)
+    else:
+        bgr = cv2.cvtColor(rgba, cv2.COLOR_RGB2BGR)
+
+    gray = cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)
+    blur = cv2.GaussianBlur(gray, (5, 5), 0)
+    thresh = cv2.adaptiveThreshold(
+        blur,
+        255,
+        cv2.ADAPTIVE_THRESH_MEAN_C,
+        cv2.THRESH_BINARY_INV,
+        25,
+        5,
+    )
+    kernel = np.ones((5, 5), np.uint8)
+    closed = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, kernel, iterations=2)
+
+    contours, _ = cv2.findContours(
+        closed, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+    )
+    contours = _filter_contours(contours, rgba.shape[1], rgba.shape[0])
+
+    estimates: list[RoomEstimate] = []
+    for contour in contours:
+        x, y, w, h = cv2.boundingRect(contour)
+        width_ft = w * PIXEL_TO_FEET
+        height_ft = h * PIXEL_TO_FEET
+        area_sqft = width_ft * height_ft
+        perimeter_ft = 2 * (width_ft + height_ft)
+        drywall_sqft = perimeter_ft * WALL_HEIGHT_FT
+        studs_count = max(1, int(np.ceil(perimeter_ft / STUD_SPACING_FT)))
+
+        estimates.append(
+            RoomEstimate(
+                rect=(x, y, w, h),
+                flooring_sqft=round(area_sqft, 2),
+                drywall_sqft=round(drywall_sqft, 2),
+                studs=studs_count,
+            )
+        )
+
+    estimates.sort(key=lambda estimate: estimate.flooring_sqft, reverse=True)
+    return estimates
+
+
+def parse_pdf(file_path: str | Path) -> dict:
+    """Parse *file_path* and return summary data used by tests."""
+
+    image, array = render_pdf_to_image(file_path)
+    rooms = detect_rooms(array)
+
+    totals = {
+        "flooring_sqft": round(sum(room.flooring_sqft for room in rooms), 2),
+        "drywall_sqft": round(sum(room.drywall_sqft for room in rooms), 2),
+        "studs": sum(room.studs for room in rooms),
+    }
 
     return {
         "page_number": 1,
-        "page_size": [1000, 2000],
-        "scale": "1/4\" = 1'-0\"",
-        "dimensions": ["12'-6\"", "15.5"],
+        "image_size": [image.width(), image.height()],
+        "room_count": len(rooms),
+        "totals": totals,
     }

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,22 +1,32 @@
-"""PyQt5 application scaffolding for the build plan estimator."""
+"""PyQt5 application for viewing PDF plans and material estimates."""
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor, QPainter, QPen, QPixmap
 from PyQt5.QtWidgets import (
     QApplication,
     QFileDialog,
     QMessageBox,
+    QGraphicsScene,
+    QGraphicsView,
+    QGraphicsRectItem,
     QPushButton,
-    QTextEdit,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
     QVBoxLayout,
     QWidget,
 )
 
-from src.engine.pdf_parser import parse_pdf
+from src.engine.pdf_parser import (
+    detect_rooms,
+    render_pdf_to_image,
+)
 
 
 class MainWindow(QWidget):
@@ -25,24 +35,42 @@ class MainWindow(QWidget):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("Build Plan Estimator")
-        self.resize(640, 480)
+        self.resize(1024, 768)
 
         self._select_button = QPushButton("Select PDF", self)
         self._select_button.clicked.connect(self._handle_select_pdf)
 
-        self._results_view = QTextEdit(self)
-        self._results_view.setReadOnly(True)
-        self._results_view.setPlaceholderText(
-            "Select a PDF to view placeholder parsing results."
+        self._scene = QGraphicsScene(self)
+        self._graphics_view = QGraphicsView(self._scene, self)
+        self._graphics_view.setRenderHints(
+            QPainter.Antialiasing | QPainter.SmoothPixmapTransform
         )
+        self._graphics_view.setDragMode(QGraphicsView.ScrollHandDrag)
+
+        self._table = QTableWidget(self)
+        self._table.setColumnCount(4)
+        self._table.setHorizontalHeaderLabels(
+            ["Room #", "Flooring (sqft)", "Drywall (sqft)", "Studs"]
+        )
+        header = self._table.horizontalHeader()
+        header.setSectionResizeMode(QHeaderView.Stretch)
+        self._table.verticalHeader().setVisible(False)
+        self._table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self._table.setSelectionMode(QTableWidget.NoSelection)
+
+        self._splitter = QSplitter(Qt.Horizontal, self)
+        self._splitter.addWidget(self._graphics_view)
+        self._splitter.addWidget(self._table)
+        self._splitter.setStretchFactor(0, 3)
+        self._splitter.setStretchFactor(1, 1)
 
         layout = QVBoxLayout()
         layout.addWidget(self._select_button)
-        layout.addWidget(self._results_view)
+        layout.addWidget(self._splitter)
         self.setLayout(layout)
 
     def _handle_select_pdf(self) -> None:
-        """Prompt the user for a PDF file and display placeholder parse data."""
+        """Prompt for a PDF, render it, and display detected room estimates."""
 
         file_path, _ = QFileDialog.getOpenFileName(
             self,
@@ -54,17 +82,67 @@ class MainWindow(QWidget):
             return
 
         try:
-            parsed_data = parse_pdf(file_path)
+            image, array = render_pdf_to_image(file_path)
         except Exception as exc:  # pragma: no cover - UI feedback path
             QMessageBox.critical(
                 self,
-                "Parsing Error",
-                f"An error occurred while parsing the PDF:\n{exc}",
+                "Render Error",
+                f"Unable to render the PDF page:\n{exc}",
             )
             return
 
-        formatted = json.dumps(parsed_data, indent=2)
-        self._results_view.setPlainText(formatted)
+        pixmap = QPixmap.fromImage(image)
+        self._scene.clear()
+        self._scene.addPixmap(pixmap)
+        self._scene.setSceneRect(pixmap.rect())
+
+        try:
+            room_estimates = detect_rooms(array)
+        except Exception as exc:  # pragma: no cover - UI feedback path
+            QMessageBox.warning(
+                self,
+                "Detection Error",
+                f"Failed to detect rooms in the PDF:\n{exc}",
+            )
+            room_estimates = []
+
+        self._draw_room_overlays(room_estimates)
+        self._populate_table(room_estimates)
+
+    def _draw_room_overlays(self, room_estimates) -> None:
+        pen = QPen(QColor("red"))
+        pen.setWidth(2)
+        for index, estimate in enumerate(room_estimates, start=1):
+            x, y, w, h = estimate.rect
+            rect_item = QGraphicsRectItem(x, y, w, h)
+            rect_item.setPen(pen)
+            rect_item.setZValue(1)
+            rect_item.setToolTip(
+                f"Room {index}\n"
+                f"Flooring: {estimate.flooring_sqft} sqft\n"
+                f"Drywall: {estimate.drywall_sqft} sqft\n"
+                f"Studs: {estimate.studs}"
+            )
+            self._scene.addItem(rect_item)
+
+    def _populate_table(self, room_estimates) -> None:
+        self._table.setRowCount(len(room_estimates))
+        for row, estimate in enumerate(room_estimates, start=0):
+            room_item = QTableWidgetItem(str(row + 1))
+            room_item.setTextAlignment(Qt.AlignCenter)
+            self._table.setItem(row, 0, room_item)
+
+            flooring_item = QTableWidgetItem(f"{estimate.flooring_sqft:.2f}")
+            flooring_item.setTextAlignment(Qt.AlignCenter)
+            self._table.setItem(row, 1, flooring_item)
+
+            drywall_item = QTableWidgetItem(f"{estimate.drywall_sqft:.2f}")
+            drywall_item.setTextAlignment(Qt.AlignCenter)
+            self._table.setItem(row, 2, drywall_item)
+
+            studs_item = QTableWidgetItem(str(estimate.studs))
+            studs_item.setTextAlignment(Qt.AlignCenter)
+            self._table.setItem(row, 3, studs_item)
 
 
 def run_app() -> None:

--- a/tests/test_pdf_parser.py
+++ b/tests/test_pdf_parser.py
@@ -1,29 +1,51 @@
-"""Tests for the placeholder PDF parser implementation."""
+"""Tests for the PDF rendering and room detection helpers."""
 
 from __future__ import annotations
 
-from src.engine.pdf_parser import parse_pdf
+from pathlib import Path
+
+import numpy as np
+from PyQt5.QtGui import QImage
+
+from src.engine.pdf_parser import (
+    RoomEstimate,
+    detect_rooms,
+    parse_pdf,
+    render_pdf_to_image,
+)
 
 
-EXPECTED_KEYS = {"page_number", "page_size", "scale", "dimensions"}
+FIXTURE = Path("tests/fixtures/sample_plan.pdf")
 
 
-def test_parse_pdf_returns_placeholder_data() -> None:
-    result = parse_pdf("fake.pdf")
+def test_render_pdf_to_image_produces_qimage_and_array() -> None:
+    image, array = render_pdf_to_image(FIXTURE)
 
-    assert isinstance(result, dict)
-    assert EXPECTED_KEYS.issubset(result.keys())
-    assert result["page_number"] == 1
-    assert isinstance(result["page_size"], list)
-    assert len(result["page_size"]) == 2
-    assert isinstance(result["dimensions"], list)
-    assert "12'-6\"" in result["dimensions"]
+    assert isinstance(image, QImage)
+    assert isinstance(array, np.ndarray)
+    assert array.ndim == 3 and array.shape[2] == 4
+    assert image.width() == array.shape[1]
+    assert image.height() == array.shape[0]
 
 
-def test_parse_pdf_accepts_pathlike() -> None:
-    class DummyPath:
-        def __fspath__(self) -> str:
-            return "dummy.pdf"
+def test_detect_rooms_returns_estimates() -> None:
+    _, array = render_pdf_to_image(FIXTURE)
+    rooms = detect_rooms(array)
 
-    result = parse_pdf(DummyPath())
-    assert result["page_number"] == 1
+    assert rooms, "Expected to detect at least one room"
+    assert all(isinstance(room, RoomEstimate) for room in rooms)
+    for estimate in rooms:
+        x, y, w, h = estimate.rect
+        assert w > 0 and h > 0
+        assert estimate.flooring_sqft > 0
+        assert estimate.drywall_sqft > 0
+        assert estimate.studs > 0
+
+
+def test_parse_pdf_returns_summary_totals() -> None:
+    summary = parse_pdf(FIXTURE)
+
+    assert summary["page_number"] == 1
+    assert summary["room_count"] >= 0
+    totals = summary["totals"]
+    assert {"flooring_sqft", "drywall_sqft", "studs"} <= totals.keys()


### PR DESCRIPTION
## Summary
- add the PyMuPDF dependency so the engine can render plan pages
- implement PDF rendering, room detection, and material takeoff estimation helpers
- replace the placeholder UI with a PDF viewer, overlays, and a material summary table
- update tests to exercise the new PDF utilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0d25dd2fc83318bddeeb98e72018c