### PR TITLE
Fix scene rect initialization with QRectF

### DIFF
--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QRectF
 from PyQt5.QtGui import QColor, QPainter, QPen, QPixmap
 from PyQt5.QtWidgets import (
     QApplication,
@@ -95,8 +95,7 @@ class MainWindow(QWidget):
         self._scene.clear()
         self._scene.addPixmap(pixmap)
         
-        from PyQt5.QtCore import QRectF
-self._scene.setSceneRect(QRectF(pixmap.rect()))
+        self._scene.setSceneRect(QRectF(pixmap.rect()))
 
         try:
             room_estimates = detect_rooms(array)


### PR DESCRIPTION
## Summary
- import QRectF alongside the other PyQt5 QtCore utilities
- wrap the pixmap rectangle in a QRectF when updating the scene rect to avoid type errors

## Testing
- pytest *(fails: ImportError: libGL.so.1 missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d194aa4f948331837446c904c00824